### PR TITLE
refactor: Changing function naming convention

### DIFF
--- a/include/console_log.h
+++ b/include/console_log.h
@@ -24,23 +24,23 @@
 
 struct ConsoleLog {
   // will display a white debug message on the screen
-  void (*log_debug)(const char* debug, const char* description,
+  void (*debug)(const char* debug, const char* description,
       const char* file, const int line, const char* func);
 
   // will display a red error message on the screen
-  void (*log_error)(const char* error, const char* description,
+  void (*error)(const char* error, const char* description,
       const char* file, const int line, const char* func);
 
   // will display a red error message on the screen and exit the program
-  void (*log_fatal)(const char* error, const char* description,
+  void (*fatal)(const char* error, const char* description,
       const char* file, const int line, const char* func);
 
   // will display a simple message on the screen
-  void (*log_message)(const char* title, const char* message,
+  void (*message)(const char* title, const char* message,
       const char* file, const int line, const char* func);
 
   // will display a yellow error message on the screen
-  void (*log_warning)(const char* warning, const char* description,
+  void (*warning)(const char* warning, const char* description,
       const char* file, const int line, const char* func);
 };
 

--- a/src/console_log.c
+++ b/src/console_log.c
@@ -30,11 +30,11 @@ struct ConsoleLog* new_console_log() {
   }
 
   // assign the public member methods
-  new_log->log_debug = log_debug;
-  new_log->log_error = log_error;
-  new_log->log_fatal = log_fatal;
-  new_log->log_message = log_message;
-  new_log->log_warning = log_warning;
+  new_log->debug = log_debug;
+  new_log->error = log_error;
+  new_log->fatal = log_fatal;
+  new_log->message = log_message;
+  new_log->warning = log_warning;
 
   return new_log;
 }

--- a/src/file_log.c
+++ b/src/file_log.c
@@ -17,7 +17,7 @@ struct FileLog* new_file_log() {
   // confirm that there is memory to allocate
   if (new_log == NULL) {
     struct ConsoleLog* log = new_console_log();
-    log->log_error("OUT_OF_MEMORY", "Failing to allocate memory "
+    log->error("OUT_OF_MEMORY", "Failing to allocate memory "
         "dynamically (using 'malloc') due to insufficient memory in the heap.",
         __FILE__, __LINE__, __func__);
     return NULL;
@@ -34,7 +34,7 @@ void destroy_file_log(struct FileLog* log) {
   // free the memory only if the log is not null reference
   if (log == NULL) {
     struct ConsoleLog* log = new_console_log();
-    log->log_warning("NULL_REFERENCE", "Attempting to use a reference "
+    log->warning("NULL_REFERENCE", "Attempting to use a reference "
         "or pointer that points to NULL, or is uninitialized.",
         __FILE__, __LINE__, __func__);
     return;
@@ -56,7 +56,7 @@ void log_to_file(const char* filename, const char* log, const char* message,
     struct ConsoleLog* log = new_console_log();
     char error_description[256];
     sprintf(error_description, "Failed to open the specified file: %s", filename);
-    log->log_error("CANNOT_OPEN_FILE", error_description,
+    log->error("CANNOT_OPEN_FILE", error_description,
         __FILE__, __LINE__, __func__);
 
     // exit the program

--- a/tests/console_log.c
+++ b/tests/console_log.c
@@ -9,34 +9,34 @@ void test_creation_and_destruction() {
   destroy_console_log(log);
 }
 
-// Test case for the log_debug() method.
-void test_log_debug() {
+// Test case for the debug() method.
+void test_debug() {
   struct ConsoleLog* log = new_console_log();
 
   // log the error to the console
-  log->log_debug("THIS IS JUST A TEST!!!", "This is a test description! XD",
+  log->debug("THIS IS JUST A TEST!!!", "This is a test description! XD",
       __FILE__, __LINE__, __func__);
 
   destroy_console_log(log);
 }
 
-// Test case for the log_error() method.
-void test_log_error() {
+// Test case for the error() method.
+void test_error() {
   struct ConsoleLog* log = new_console_log();
 
   // log the error to the console
-  log->log_error("THIS IS JUST A TEST!!!", "This is a test description! XD",
+  log->error("THIS IS JUST A TEST!!!", "This is a test description! XD",
       __FILE__, __LINE__, __func__);
 
   destroy_console_log(log);
 }
 
-// Test case for the log_message() method.
-void test_log_message() {
+// Test case for the message() method.
+void test_message() {
   struct ConsoleLog* log = new_console_log();
 
   // log the message to the console
-  log->log_message("THIS IS JUST A TEST!!!", "If you see this message, don't "
+  log->message("THIS IS JUST A TEST!!!", "If you see this message, don't "
       "worry, this is just a test. :D \nActually, seeing this means the test "
       "is working as it should.",
       __FILE__, __LINE__, __func__);
@@ -44,23 +44,23 @@ void test_log_message() {
   destroy_console_log(log);
 }
 
-// Test case for the log_warning() method.
-void test_log_warning() {
+// Test case for the warning() method.
+void test_warning() {
   struct ConsoleLog* log = new_console_log();
 
   // log the warning to the console
-  log->log_warning("THIS IS JUST A TEST!!!", "This is a test description! XD",
+  log->warning("THIS IS JUST A TEST!!!", "This is a test description! XD",
       __FILE__, __LINE__, __func__);
 
   destroy_console_log(log);
 }
 
-// Test case for the log_fatal() method.
-void test_log_fatal() {
+// Test case for the fatal() method.
+void test_fatal() {
   struct ConsoleLog* log = new_console_log();
 
   // log the error to the console
-  log->log_fatal("THIS IS JUST A TEST!!!", "After this test, the program "
+  log->fatal("THIS IS JUST A TEST!!!", "After this test, the program "
       "will exit with a status code of 1. This is GOOD!!",
       __FILE__, __LINE__, __func__);
 
@@ -69,10 +69,10 @@ void test_log_fatal() {
 
 int main() {
   test_creation_and_destruction();
-  test_log_debug();
-  test_log_error();
-  test_log_message();
-  test_log_warning();
-  test_log_fatal();
+  test_debug();
+  test_error();
+  test_message();
+  test_warning();
+  test_fatal();
   return 0;
 }


### PR DESCRIPTION
For a simpler approach and library usage, we should change all names by removing the 'log_' prefix of all functions. Checkout #7 issue for more details.