### PR TITLE
feat: Make all log functions public

### DIFF
--- a/include/console_log.h
+++ b/include/console_log.h
@@ -50,4 +50,26 @@ struct ConsoleLog* new_console_log();
 // the destructor should be used to destroy an existing instance
 void destroy_console_log(struct ConsoleLog* log);
 
+/* MARK: PUBLIC FUNCTIONS */
+
+// will display a white debug message on the screen
+void log_debug(const char* debug, const char* description,
+    const char* file, const int line, const char* func);
+
+// will display a red error message on the screen
+void log_error(const char* error, const char* description,
+    const char* file, const int line, const char* func);
+
+// will display a red error message on the screen and exit the program
+void log_fatal(const char* error, const char* description,
+  const char* file, const int line, const char* func);
+
+// will display a simple message on the screen
+void log_message(const char* title, const char* message,
+  const char* file, const int line, const char* func);
+
+// will display a yellow error message on the screen
+void log_warning(const char* warning, const char* description,
+  const char* file, const int line, const char* func);
+
 #endif /* CONSOLE_LOG_H */

--- a/src/console_log.c
+++ b/src/console_log.c
@@ -1,7 +1,5 @@
 #include "../include/console_log.h"
 
-#include <time.h>
-
 // MARK: PUBLIC MEMBER METHODS PROTOTYPES
 void log_debug(const char* debug, const char* description,
     const char* file, const int line, const char* func);


### PR DESCRIPTION
In '/src' all of the functions used for logging, should also be public so the users can use those functions without an instance. Checkout #9 for more details.