### PR TITLE
refactor: Change messge to info

### DIFF
--- a/include/console_log.h
+++ b/include/console_log.h
@@ -42,7 +42,7 @@ struct ConsoleLog {
     const int index, const int line, const char* func);
 
   // will display a simple message on the screen
-  void (*message)(struct ConsoleLog* self,
+  void (*info)(struct ConsoleLog* self,
     const int index, const int line, const char* func);
 
   // will display a yellow error message on the screen
@@ -72,7 +72,7 @@ void log_fatal(const char* exception, const char* description,
   const char* file, const int line, const char* func);
 
 // will display a simple message on the screen
-void log_message(const char* title, const char* description,
+void log_info(const char* title, const char* description,
   const char* file, const int line, const char* func);
 
 // will display a yellow error message on the screen

--- a/src/console_log.c
+++ b/src/console_log.c
@@ -27,7 +27,7 @@ void log_error(const char* exception, const char* description,
     const char* file, const int line, const char* func);
 void log_fatal(const char* exception, const char* description,
     const char* file, const int line, const char* func);
-void log_message(const char* title, const char* description,
+void log_info(const char* title, const char* description,
     const char* file, const int line, const char* func);
 void log_warning(const char* warning, const char* description,
     const char* file, const int line, const char* func);
@@ -57,7 +57,7 @@ struct ConsoleLog* new_console_log(const char** exceptions,
   new_log->debug = display_debug_message;
   new_log->error = display_error_message;
   new_log->fatal = display_fatal_message;
-  new_log->message = display_info_message;
+  new_log->info = display_info_message;
   new_log->warning = display_warning_message;
 
   return new_log;
@@ -102,7 +102,7 @@ static void display_fatal_message(struct ConsoleLog* self,
 // This function will simply call the public function with enforced parameters
 static void display_info_message(struct ConsoleLog* self,
     const int index, const int line, const char* func) {
-  log_message(self->exceptions[index],
+  log_info(self->exceptions[index],
       self->descriptions[index], self->file, line, func);
 }
 
@@ -146,7 +146,7 @@ void log_fatal(const char* exception, const char* description,
 }
 
 // This function will display a simple message on the screen.
-void log_message(const char* title, const char* description,
+void log_info(const char* title, const char* description,
     const char* file, const int line, const char* func) {
   printf("\n");
   printf("[INFO] %s:%d in function ‘%s’ \n", file, line, func);

--- a/tests/console_log.c
+++ b/tests/console_log.c
@@ -14,7 +14,7 @@
 const char* ex[] = {
   "TEST_DEBUG",
   "TEST_ERROR",
-  "TEST_MESSAGE",
+  "TEST_INFO",
   "TEST_WARNING",
   "TEST_FATAL"
 };
@@ -22,7 +22,7 @@ const char* ex[] = {
 const char* log_ex[] = {
   "This is just a test description for debug! XD",
   "This is just a test description for error! XD",
-  "This is just a test description for message! XD",
+  "This is just a test description for info! XD",
   "This is just a test description for warning! XD",
   "This is just a test description for fatal! XD\n"
     "After this test, the program will exit with a status code of 1."
@@ -53,12 +53,12 @@ void test_error() {
   destroy_console_log(log);
 }
 
-// Test case for the message() method.
-void test_message() {
+// Test case for the info() method.
+void test_info() {
   struct ConsoleLog* log = new_console_log(ex, log_ex, __FILE__);
 
   // log the message to the console
-  log->message(log, 2, __LINE__, __func__);
+  log->info(log, 2, __LINE__, __func__);
   destroy_console_log(log);
 }
 
@@ -84,7 +84,7 @@ int main() {
   test_creation_and_destruction();
   test_debug();
   test_error();
-  test_message();
+  test_info();
   test_warning();
   test_fatal();
   return 0;


### PR DESCRIPTION
The naming convention of the 'message' function is not right, we should change it into 'info'. Checkout issue #4 for more details.